### PR TITLE
Fix/invariant culture

### DIFF
--- a/src/urdf/UrdfToUnity/Urdf/Models/Attributes/RgbAttribute.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Attributes/RgbAttribute.cs
@@ -1,4 +1,6 @@
-﻿using UrdfToUnity.Util;
+﻿using System;
+using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Attributes
 {
@@ -63,7 +65,7 @@ namespace UrdfToUnity.Urdf.Models.Attributes
         /// <returns>"R G B"</returns>
         public override string ToString()
         {
-            return $"{R} {G} {B}";
+            return String.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", R, G, B);
         }
 
         protected bool Equals(RgbAttribute other)

--- a/src/urdf/UrdfToUnity/Urdf/Models/Attributes/RpyAttribute.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Attributes/RpyAttribute.cs
@@ -1,4 +1,7 @@
-﻿namespace UrdfToUnity.Urdf.Models.Attributes
+﻿using System;
+using System.Globalization;
+
+namespace UrdfToUnity.Urdf.Models.Attributes
 {
     /// <summary>
     /// Represents the fixed axis roll, pitch and yaw angles in radians.
@@ -49,7 +52,7 @@
         /// <returns>"R P Y"</returns>
         public override string ToString()
         {
-            return $"{R} {P} {Y}";
+            return String.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", R, P, Y);
         }
 
         protected bool Equals(RpyAttribute other)

--- a/src/urdf/UrdfToUnity/Urdf/Models/Attributes/ScaleAttribute.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Attributes/ScaleAttribute.cs
@@ -1,4 +1,7 @@
-﻿namespace UrdfToUnity.Urdf.Models.Attributes
+﻿using System;
+using System.Globalization;
+
+namespace UrdfToUnity.Urdf.Models.Attributes
 {
     /// <summary>
     /// Represents the scale attribute of a trimesh element.
@@ -42,7 +45,7 @@
         /// <returns>"X Y Z"</returns>
         public override string ToString()
         {
-            return $"{X} {Y} {Z}";
+            return String.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", X, Y, Z);
         }
 
         protected bool Equals(ScaleAttribute other)

--- a/src/urdf/UrdfToUnity/Urdf/Models/Attributes/SizeAttribute.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Attributes/SizeAttribute.cs
@@ -1,4 +1,7 @@
-﻿namespace UrdfToUnity.Urdf.Models.Attributes
+﻿using System;
+using System.Globalization;
+
+namespace UrdfToUnity.Urdf.Models.Attributes
 {
     /// <summary>
     /// Represents the three side lengths of a box shape.
@@ -41,7 +44,7 @@
         /// <returns>"L W H"</returns>
         public override string ToString()
         {
-            return $"{Length} {Width} {Height}";
+            return String.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", Length, Width, Height);
         }
 
         protected bool Equals(SizeAttribute other)

--- a/src/urdf/UrdfToUnity/Urdf/Models/Attributes/XyzAttribute.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Attributes/XyzAttribute.cs
@@ -1,4 +1,7 @@
-﻿namespace UrdfToUnity.Urdf.Models.Attributes
+﻿using System;
+using System.Globalization;
+
+namespace UrdfToUnity.Urdf.Models.Attributes
 {
     /// <summary>
     /// Represents the x, y, z offset.
@@ -50,7 +53,7 @@
         /// <returns>"X Y Z"</returns>
         public override string ToString()
         {
-            return $"{X} {Y} {Z}";
+            return String.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", X, Y, Z);
         }
 
         protected bool Equals(XyzAttribute other)

--- a/src/urdf/UrdfToUnity/Urdf/Models/Joints/Axis.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Joints/Axis.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Urdf.Models.Attributes;
+﻿using System.Globalization;
+using UrdfToUnity.Urdf.Models.Attributes;
 using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Joints

--- a/src/urdf/UrdfToUnity/Urdf/Models/Joints/Calibration.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Joints/Calibration.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Joints
 {
@@ -46,8 +47,8 @@ namespace UrdfToUnity.Urdf.Models.Joints
         public override string ToString()
         {
             return new XmlStringBuilder(UrdfSchema.CALIBRATION_ELEMENT_NAME)
-                .AddAttribute(UrdfSchema.RISING_ATTRIBUTE_NAME, this.Rising)
-                .AddAttribute(UrdfSchema.FALLING_ATTRIBUTE_NAME, this.Falling)
+                .AddAttribute(UrdfSchema.RISING_ATTRIBUTE_NAME, this.Rising.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.FALLING_ATTRIBUTE_NAME, this.Falling.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Joints/Dynamics.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Joints/Dynamics.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Joints
 {
@@ -46,8 +47,8 @@ namespace UrdfToUnity.Urdf.Models.Joints
         public override string ToString()
         {
             return new XmlStringBuilder(UrdfSchema.DYNAMICS_ELEMENT_NAME)
-                .AddAttribute(UrdfSchema.DAMPING_ATTRIBUTE_NAME, this.Damping)
-                .AddAttribute(UrdfSchema.FRICTION_ATTRIBUTE_NAME, this.Friction)
+                .AddAttribute(UrdfSchema.DAMPING_ATTRIBUTE_NAME, this.Damping.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.FRICTION_ATTRIBUTE_NAME, this.Friction.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Joints/Limit.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Joints/Limit.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Joints
 {
@@ -62,10 +63,10 @@ namespace UrdfToUnity.Urdf.Models.Joints
         public override string ToString()
         {
             return new XmlStringBuilder(UrdfSchema.LIMIT_ELEMENT_NAME)
-                .AddAttribute(UrdfSchema.EFFORT_ATTRIBUTE_NAME, this.Effort)
-                .AddAttribute(UrdfSchema.VELOCITY_ATTRIBUTE_NAME, this.Velocity)
-                .AddAttribute(UrdfSchema.LOWER_ATTRIBUTE_NAME, this.Lower)
-                .AddAttribute(UrdfSchema.UPPER_ATTRIBUTE_NAME, this.Upper)
+                .AddAttribute(UrdfSchema.EFFORT_ATTRIBUTE_NAME, this.Effort.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.VELOCITY_ATTRIBUTE_NAME, this.Velocity.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.LOWER_ATTRIBUTE_NAME, this.Lower.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.UPPER_ATTRIBUTE_NAME, this.Upper.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Joints/Mimic.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Joints/Mimic.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Joints
 {
@@ -64,8 +65,8 @@ namespace UrdfToUnity.Urdf.Models.Joints
         {
             return new XmlStringBuilder(UrdfSchema.MIMIC_ELEMENT_NAME)
                 .AddAttribute(UrdfSchema.JOINT_ATTRIBUTE_NAME, this.Joint.Name)
-                .AddAttribute(UrdfSchema.MULTIPLIER_ATTRIBUTE_NAME, this.Multiplier)
-                .AddAttribute(UrdfSchema.OFFSET_ATTRIBUTE_NAME, this.Offset)
+                .AddAttribute(UrdfSchema.MULTIPLIER_ATTRIBUTE_NAME, this.Multiplier.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.OFFSET_ATTRIBUTE_NAME, this.Offset.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Joints/SafetyController.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Joints/SafetyController.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Joints
 {
@@ -67,10 +68,10 @@ namespace UrdfToUnity.Urdf.Models.Joints
         public override string ToString()
         {
             return new XmlStringBuilder(UrdfSchema.SAFETY_CONTROLLER_ELEMENT_NAME)
-                .AddAttribute(UrdfSchema.K_VELOCITY_ATTRIBUTE_NAME, this.KVelocity)
-                .AddAttribute(UrdfSchema.K_POSITION_ATTRIBUTE_NAME, this.KPosition)
-                .AddAttribute(UrdfSchema.LOWER_LIMIT_ATTRIBUTE_NAME, this.SoftLowerLimit)
-                .AddAttribute(UrdfSchema.UPPER_LIMIT_ATTRIBUTE_NAME, this.SoftUpperLimit)
+                .AddAttribute(UrdfSchema.K_VELOCITY_ATTRIBUTE_NAME, this.KVelocity.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.K_POSITION_ATTRIBUTE_NAME, this.KPosition.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.LOWER_LIMIT_ATTRIBUTE_NAME, this.SoftLowerLimit.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.UPPER_LIMIT_ATTRIBUTE_NAME, this.SoftUpperLimit.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Links/Geometries/Cylinder.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Links/Geometries/Cylinder.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Links.Geometries
 {
@@ -38,8 +39,8 @@ namespace UrdfToUnity.Urdf.Models.Links.Geometries
         public override string ToString()
         {
             return new XmlStringBuilder(UrdfSchema.CYLINDER_ELEMENT_NAME)
-                .AddAttribute(UrdfSchema.RADIUS_ATTRIBUTE_NAME, this.Radius)
-                .AddAttribute(UrdfSchema.LENGTH_ATTRIBUTE_NAME, this.Length)
+                .AddAttribute(UrdfSchema.RADIUS_ATTRIBUTE_NAME, this.Radius.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.LENGTH_ATTRIBUTE_NAME, this.Length.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Links/Geometries/Sphere.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Links/Geometries/Sphere.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Links.Geometries
 {
@@ -30,7 +31,7 @@ namespace UrdfToUnity.Urdf.Models.Links.Geometries
         public override string ToString()
         {
             return new XmlStringBuilder(UrdfSchema.SPHERE_ELEMENT_NAME)
-                .AddAttribute(UrdfSchema.RADIUS_ATTRIBUTE_NAME, this.Radius)
+                .AddAttribute(UrdfSchema.RADIUS_ATTRIBUTE_NAME, this.Radius.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Links/Inertials/Inertia.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Links/Inertials/Inertia.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Links.Inertials
 {
@@ -76,12 +77,12 @@ namespace UrdfToUnity.Urdf.Models.Links.Inertials
         public override string ToString()
         {
             return new XmlStringBuilder(UrdfSchema.INERTIA_ELEMENT_NAME)
-                .AddAttribute(UrdfSchema.IXX_ATTRIBUTE_NAME, this.Ixx)
-                .AddAttribute(UrdfSchema.IXY_ATTRIBUTE_NAME, this.Ixy)
-                .AddAttribute(UrdfSchema.IXZ_ATTRIBUTE_NAME, this.Ixz)
-                .AddAttribute(UrdfSchema.IYY_ATTRIBUTE_NAME, this.Iyy)
-                .AddAttribute(UrdfSchema.IYZ_ATTRIBUTE_NAME, this.Iyz)
-                .AddAttribute(UrdfSchema.IZZ_ATTRIBUTE_NAME, this.Izz)
+                .AddAttribute(UrdfSchema.IXX_ATTRIBUTE_NAME, this.Ixx.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.IXY_ATTRIBUTE_NAME, this.Ixy.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.IXZ_ATTRIBUTE_NAME, this.Ixz.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.IYY_ATTRIBUTE_NAME, this.Iyy.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.IYZ_ATTRIBUTE_NAME, this.Iyz.ToString(CultureInfo.InvariantCulture))
+                .AddAttribute(UrdfSchema.IZZ_ATTRIBUTE_NAME, this.Izz.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Links/Inertials/Mass.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Links/Inertials/Mass.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Util;
+﻿using System.Globalization;
+using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Links.Inertials
 {
@@ -32,7 +33,7 @@ namespace UrdfToUnity.Urdf.Models.Links.Inertials
         public override string ToString()
         {
             return new XmlStringBuilder(UrdfSchema.MASS_ELEMENT_NAME)
-                .AddAttribute(UrdfSchema.MASS_VALUE_ATTRIBUTE_NAME, this.Value)
+                .AddAttribute(UrdfSchema.MASS_VALUE_ATTRIBUTE_NAME, this.Value.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Urdf/Models/Links/Visuals/Color.cs
+++ b/src/urdf/UrdfToUnity/Urdf/Models/Links/Visuals/Color.cs
@@ -1,4 +1,5 @@
-﻿using UrdfToUnity.Urdf.Models.Attributes;
+﻿using System.Globalization;
+using UrdfToUnity.Urdf.Models.Attributes;
 using UrdfToUnity.Util;
 
 namespace UrdfToUnity.Urdf.Models.Links.Visuals
@@ -57,7 +58,7 @@ namespace UrdfToUnity.Urdf.Models.Links.Visuals
         {
             return new XmlStringBuilder(UrdfSchema.COLOR_ELEMENT_NAME)
                 .AddAttribute(UrdfSchema.RGB_ATTRIBUTE_NAME, this.Rgb)
-                .AddAttribute(UrdfSchema.ALPHA_ATTRIBUTE_NAME, this.Alpha)
+                .AddAttribute(UrdfSchema.ALPHA_ATTRIBUTE_NAME, this.Alpha.ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 

--- a/src/urdf/UrdfToUnity/Util/RegexUtils.cs
+++ b/src/urdf/UrdfToUnity/Util/RegexUtils.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -70,7 +72,7 @@ namespace UrdfToUnity.Util
             Preconditions.IsTrue(REAL_NUMBER_REGEX.IsMatch(input), $"Provided input string <{input}> is not a double representation");
 
             Match match = REAL_NUMBER_REGEX.Match(input);
-            return Double.Parse(match.Value);
+            return Double.Parse(match.Value, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -101,7 +103,7 @@ namespace UrdfToUnity.Util
 
             for (int i = 0; i < matches.Count; i++)
             {
-                doubles[i] = Double.Parse(matches[i].Value);
+                doubles[i] = Double.Parse(matches[i].Value, CultureInfo.InvariantCulture);
             }
 
             return doubles;

--- a/src/urdf/UrdfToUnity/Util/RegexUtils.cs
+++ b/src/urdf/UrdfToUnity/Util/RegexUtils.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 

--- a/src/urdf/UrdfToUnityTest/Parse/Xml/Links/Inertials/MassParserTest.cs
+++ b/src/urdf/UrdfToUnityTest/Parse/Xml/Links/Inertials/MassParserTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -22,7 +23,7 @@ namespace UrdfToUnityTest.Parse.Xml.Links.Inertials
 
             foreach (double value in testValues)
             {
-                string xml = String.Format(FORMAT_STRING, value);
+                string xml = String.Format(CultureInfo.InvariantCulture, FORMAT_STRING, value);
                 this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
                 Mass mass = this.parser.Parse(xmlDoc.DocumentElement);
 

--- a/src/urdf/UrdfToUnityTest/Parse/Xml/Links/Visuals/ColorParserTest.cs
+++ b/src/urdf/UrdfToUnityTest/Parse/Xml/Links/Visuals/ColorParserTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -19,7 +20,7 @@ namespace UrdfToUnityTest.Parse.Xml.Links.Visuals
             int r = 1;
             int g = 2;
             int b = 3;
-            string xml = String.Format("<color rgb='{0} {1} {2}'/>", r, g, b);
+            string xml = String.Format(CultureInfo.InvariantCulture, "<color rgb='{0} {1} {2}'/>", r, g, b);
 
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Color color = this.parser.Parse(this.xmlDoc.DocumentElement);
@@ -37,7 +38,7 @@ namespace UrdfToUnityTest.Parse.Xml.Links.Visuals
             int g = 2;
             int b = 3;
             double alpha = 0d;
-            string xml = String.Format("<color rgb='{0} {1} {2}' alpha='{3}'/>", r, g, b, alpha);
+            string xml = String.Format(CultureInfo.InvariantCulture, "<color rgb='{0} {1} {2}' alpha='{3}'/>", r, g, b, alpha);
 
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Color color = this.parser.Parse(this.xmlDoc.DocumentElement);
@@ -55,7 +56,7 @@ namespace UrdfToUnityTest.Parse.Xml.Links.Visuals
             double g = 0.5;
             double b = 0.75;
             double alpha = 0d;
-            string xml = String.Format("<color rgba='{0} {1} {2} {3}'/>", r, g, b, alpha);
+            string xml = String.Format(CultureInfo.InvariantCulture, "<color rgba='{0} {1} {2} {3}'/>", r, g, b, alpha);
 
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Color color = this.parser.Parse(this.xmlDoc.DocumentElement);
@@ -86,7 +87,7 @@ namespace UrdfToUnityTest.Parse.Xml.Links.Visuals
             int r = 1;
             int g = 2;
             int b = 3;
-            string xml = String.Format("<color rgb='{0} {1} {2}' alpha='no alpha'/>", r, g, b);
+            string xml = String.Format(CultureInfo.InvariantCulture, "<color rgb='{0} {1} {2}' alpha='no alpha'/>", r, g, b);
 
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Color color = this.parser.Parse(this.xmlDoc.DocumentElement);
@@ -103,7 +104,7 @@ namespace UrdfToUnityTest.Parse.Xml.Links.Visuals
             double r = 0.25;
             double g = 0.5;
             double b = 0.75;
-            string xml = String.Format("<color rgba='{0} {1} {2}'/>", r, g, b); // Missing value
+            string xml = String.Format(CultureInfo.InvariantCulture, "<color rgba='{0} {1} {2}'/>", r, g, b); // Missing value
 
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Color color = this.parser.Parse(this.xmlDoc.DocumentElement);

--- a/src/urdf/UrdfToUnityTest/Parse/Xml/OriginParserTest.cs
+++ b/src/urdf/UrdfToUnityTest/Parse/Xml/OriginParserTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -32,7 +33,7 @@ namespace UrdfToUnityTest.Parse.Xml
             double rpyY = 0;
 
             // <origin rpy='0 1.57075 0' xyz='0 0 -0.3'/>
-            string xml = String.Format("<origin rpy='{0} {1} {2}' xyz='{3} {4} {5}'/>", rpyR, rpyP, rpyY, xyzX, xyzY, xyzZ);
+            string xml = String.Format(CultureInfo.InvariantCulture, "<origin rpy='{0} {1} {2}' xyz='{3} {4} {5}'/>", rpyR, rpyP, rpyY, xyzX, xyzY, xyzZ);
             
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Origin origin = this.parser.Parse(xmlDoc.DocumentElement);
@@ -56,7 +57,7 @@ namespace UrdfToUnityTest.Parse.Xml
             double rpyY = 0;
 
             // <origin rpy='0 1.57075 0' xyz='0 0 -0.3'/> with leading and trailing whitespace
-            string xml = String.Format("<origin rpy='{0} {1} {2} ' xyz=' {3} {4}   {5}'/>", rpyR, rpyP, rpyY, xyzX, xyzY, xyzZ);
+            string xml = String.Format(CultureInfo.InvariantCulture, "<origin rpy='{0} {1} {2} ' xyz=' {3} {4}   {5}'/>", rpyR, rpyP, rpyY, xyzX, xyzY, xyzZ);
 
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Origin origin = this.parser.Parse(xmlDoc.DocumentElement);
@@ -77,7 +78,7 @@ namespace UrdfToUnityTest.Parse.Xml
             double xyzZ = .25;
 
             // <origin xyz='0 -0.22 0.25'/>
-            string xml = String.Format("<origin xyz='{0} {1} {2}'/>", xyzX, xyzY, xyzZ);
+            string xml = String.Format(CultureInfo.InvariantCulture, "<origin xyz='{0} {1} {2}'/>", xyzX, xyzY, xyzZ);
 
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Origin origin = this.parser.Parse(xmlDoc.DocumentElement);
@@ -99,7 +100,7 @@ namespace UrdfToUnityTest.Parse.Xml
             double rpyY = 0;
 
             // <origin rpy='0 1.57075 0'/>
-            string xml = String.Format("<origin rpy='{0} {1} {2}'/>", rpyR, rpyP, rpyY);
+            string xml = String.Format(CultureInfo.InvariantCulture, "<origin rpy='{0} {1} {2}'/>", rpyR, rpyP, rpyY);
 
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Origin origin = this.parser.Parse(xmlDoc.DocumentElement);
@@ -119,7 +120,7 @@ namespace UrdfToUnityTest.Parse.Xml
             double y = 2;
             double z = 3;
 
-            string xml = String.Format("<origin xyz='{0} {1} {2}' rpy='1 2'/>", x, y, z); // Missing y-value for rpy
+            string xml = String.Format(CultureInfo.InvariantCulture, "<origin xyz='{0} {1} {2}' rpy='1 2'/>", x, y, z); // Missing y-value for rpy
             
             this.xmlDoc.Load(XmlReader.Create(new StringReader(xml)));
             Origin origin = this.parser.Parse(xmlDoc.DocumentElement);

--- a/src/urdf/UrdfToUnityTest/Util/RegexUtilsTest.cs
+++ b/src/urdf/UrdfToUnityTest/Util/RegexUtilsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using UrdfToUnity.Util;
@@ -72,7 +73,7 @@ namespace UrdfToUnityTest.Util
         {
             double pi = 3.14;
             double tau = 6.28;
-            string numbersAsString = pi.ToString() + " " + tau.ToString();
+            string numbersAsString = pi.ToString(CultureInfo.InvariantCulture) + " " + tau.ToString(CultureInfo.InvariantCulture);
             double[] results = RegexUtils.MatchDoubles(numbersAsString);
 
             Assert.IsTrue(results.Length == 2);


### PR DESCRIPTION
Hello,
Thanks for this nice software.
Please consider this pull request, which is making explicit the use of CultureInfo.InvariantCulture in order to make this software run with all locales, also on non-US computers, e.g. for regional settings using `,` instead of `.` as a default decimal separator. Otherwise, functions such as `Double.Parse()` would fail.
I think it is better to have some explicit code, without assumptions on higher-level configurations.